### PR TITLE
Data Abstraction Layer

### DIFF
--- a/codec/yaml.go
+++ b/codec/yaml.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/lukasjarosch/skipper/data"
 	"gopkg.in/yaml.v3"
+
+	"github.com/lukasjarosch/skipper/data"
 )
 
 type YamlCodec struct{}
@@ -15,8 +16,8 @@ func NewYamlCodec() YamlCodec {
 	return YamlCodec{}
 }
 
-func (codec YamlCodec) Unmarshal(in []byte) (data.Map, error) {
-	var out data.Map
+func (codec YamlCodec) Unmarshal(in []byte) (map[string]interface{}, error) {
+	var out map[string]interface{}
 	err := codec.UnmarshalTarget(in, &out)
 	if err != nil {
 		return nil, err
@@ -48,13 +49,13 @@ func (codec YamlCodec) UnmarshalPath(in []byte, path data.Path, target interface
 		return fmt.Errorf("cannot decode with path: target must be a pointer")
 	}
 
-	var out data.Map
+	var out map[string]interface{}
 	err := yaml.Unmarshal(in, &out)
 	if err != nil {
 		return err
 	}
 
-	tree, err := out.Get(path)
+	tree, err := data.Get(out, path.String())
 	if err != nil {
 		return err
 	}

--- a/data/container.go
+++ b/data/container.go
@@ -18,7 +18,7 @@ var (
 // The data can have only one key, which must match the container name.
 // So a container named 'foo' must have data like 'map[string]interface{"foo": ....}'
 type Container struct {
-	name string
+	Name string
 	data map[string]interface{}
 }
 
@@ -66,7 +66,7 @@ func NewContainer(name string, data map[string]interface{}) (*Container, error) 
 	}
 
 	c := &Container{
-		name: name,
+		Name: name,
 		data: data,
 	}
 
@@ -88,8 +88,8 @@ func (container *Container) Get(path Path) (Value, error) {
 	}
 
 	// make sure the path is absolute and contains the container name as first segment (aka root key)
-	if path.First() != container.name {
-		path = path.Prepend(container.name)
+	if path.First() != container.Name {
+		path = path.Prepend(container.Name)
 	}
 
 	ret, err := DeepGet(container.data, []string(path))
@@ -121,8 +121,8 @@ func (container *Container) Set(path Path, value interface{}) error {
 	}
 
 	// ensure path is absolute
-	if path.First() != container.name {
-		path = path.Prepend(container.name)
+	if path.First() != container.Name {
+		path = path.Prepend(container.Name)
 	}
 
 	ret, err := DeepSet(container.data, path, value)

--- a/data/reflect.go
+++ b/data/reflect.go
@@ -105,7 +105,7 @@ func IsInteger(in interface{}) bool {
 	return false
 }
 
-// Dectect whether the concrete underlying value of the given input is one or more
+// Detect whether the concrete underlying value of the given input is one or more
 // Kinds of value.
 func IsKind(in interface{}, kinds ...reflect.Kind) bool {
 	var inT reflect.Type

--- a/data/value.go
+++ b/data/value.go
@@ -5,7 +5,9 @@ import (
 	"time"
 )
 
-// Value represents a generic value that originates fom [Data]
+var NilValue = Value{Raw: nil}
+
+// Value represents a generic value that originates from the underlying data.
 type Value struct {
 	Raw interface{}
 }


### PR DESCRIPTION
The goal of this MR is to get rid of the low-level usage of `map[string]interface{}` and provide a more abstract way to interact with data.

The data abstraction layer is going to be the new core of skipper and must handle all data related tasks such as
- reading files
- decoding data
- address data
- set data dynamically
- merge data

### Goals
- Reduce the required usage of the raw `map[string]interface{}` by introducing a `Container` type which encapsulates the raw map. 
- Replace the unnecessary complicated `[]interface{}` type used to address data with something based on `[]string` (`Path`) 
- Provide a wrapper for actual "Values"
- Provide an agnostic codec layer to decouple raw data and decoded `map[string]interface{}` data
 - Introduce a new `Inventory` which is responsible for managing namespaced containers.
- Introduce a `FileContainer` which is going to be the main container type. It will only be able to read data from files.
- Introduce a `ManagedFileContainer` which is going to be used by containers which files are fully managed by Skipper (secrets) and should not be modified manually (maybe even add a hash to ensure that) 