### PR TITLE
feat: save public key or its ID to secretFileData

### DIFF
--- a/secret.go
+++ b/secret.go
@@ -2,6 +2,7 @@ package skipper
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -231,7 +232,10 @@ func secretYamlFileLoader(secretFileList *[]*SecretFile) YamlFileLoaderFunc {
 
 // Value returns the actual secret value.
 func (s *Secret) Value() (string, error) {
-	return s.Driver.Decrypt(s.Data.Data, s.Data.PublicKey)
+	if s.Driver.GetKey() != s.Data.Key {
+		fmt.Fprintf(os.Stderr, "key in secret file '%s' differs from the key in the inventory\n", s.Path())
+	}
+	return s.Driver.Decrypt(s.Data.Data, s.Data.Key)
 }
 
 // FullName returns the full secret name as it would be expected to ocurr in a class/target.

--- a/secret.go
+++ b/secret.go
@@ -34,9 +34,9 @@ func NewSecret(secretFile *SecretFile, driver string, alternative *Call, path []
 
 // SecretFileData describes the generic structure of secret files.
 type SecretFileData struct {
-	Data      string `yaml:"data"`
-	Type      string `yaml:"type"`
-	PublicKey string `yaml:"publickey"`
+	Data string `yaml:"data"`
+	Type string `yaml:"type"`
+	Key  string `yaml:"key"`
 }
 
 // NewSecretData constructs a [Data] map as it is required for secrets.
@@ -49,9 +49,9 @@ func NewSecretData(data string, driver string, key string) (*SecretFileData, err
 	}
 
 	return &SecretFileData{
-		Data:      data,
-		Type:      driver,
-		PublicKey: key,
+		Data: data,
+		Type: driver,
+		Key:  key,
 	}, nil
 }
 
@@ -143,7 +143,7 @@ func (secret *Secret) attemptCreate(fs afero.Fs, secretPath string) error {
 	}
 
 	// create new Data map which can then be written into the secret file
-	secretFileData, err := NewSecretData(encryptedData, secret.Driver.Type(), secret.Driver.GetPublicKey())
+	secretFileData, err := NewSecretData(encryptedData, secret.Driver.Type(), secret.Driver.GetKey())
 	if err != nil {
 		return fmt.Errorf("could not create NewSecretData: %w", err)
 	}

--- a/secret/driver.go
+++ b/secret/driver.go
@@ -9,7 +9,7 @@ import (
 
 type Driver interface {
 	Type() string
-	GetPublicKey() string
+	GetKey() string
 	Encrypt(data string) (string, error)
 	// if key is set, use that one for decryption, otherwise use the key set in the driver (if available)
 	Decrypt(encrypted string, key string) (string, error)

--- a/secret/driver.go
+++ b/secret/driver.go
@@ -9,8 +9,10 @@ import (
 
 type Driver interface {
 	Type() string
+	GetPublicKey() string
 	Encrypt(data string) (string, error)
-	Decrypt(encrypted string) (string, error)
+	// if key is set, use that one for decryption, otherwise use the key set in the driver (if available)
+	Decrypt(encrypted string, key string) (string, error)
 }
 
 type ConfigurableDriver interface {

--- a/secret/driver/aes.go
+++ b/secret/driver/aes.go
@@ -36,7 +36,9 @@ func (driver *Aes) Configure(config map[string]interface{}) error {
 	return nil
 }
 
-func (driver *Aes) Decrypt(encrypted string) (string, error) {
+func (driver *Aes) Decrypt(encrypted string, key string) (string, error) {
+	// key is dismissed, as we always use the key in the driver config here
+
 	decrypted, err := driver.decrypt([]byte(driver.config.Key), encrypted)
 	if err != nil {
 		return "", err
@@ -106,4 +108,8 @@ func (driver *Aes) decrypt(key []byte, secure string) (decoded string, err error
 
 func (driver *Aes) Type() string {
 	return "aes"
+}
+
+func (driver *Aes) GetPublicKey() string {
+	return "aesIsSymmetricThereIsNoPublicKey"
 }

--- a/secret/driver/aes.go
+++ b/secret/driver/aes.go
@@ -110,6 +110,6 @@ func (driver *Aes) Type() string {
 	return "aes"
 }
 
-func (driver *Aes) GetPublicKey() string {
-	return "aesIsSymmetricThereIsNoPublicKey"
+func (driver *Aes) GetKey() string {
+	return "aesIsSymmetricThereIsNoKey"
 }

--- a/secret/driver/azure.go
+++ b/secret/driver/azure.go
@@ -170,6 +170,6 @@ func (driver *Azure) Type() string {
 	return "azurekv"
 }
 
-func (driver Azure) GetPublicKey() string {
+func (driver Azure) GetKey() string {
 	return driver.config.KeyId
 }

--- a/secret/driver/azure.go
+++ b/secret/driver/azure.go
@@ -28,6 +28,7 @@ type azureConfig struct {
 	// IgnoreVersion will ignore any key version, even if given, and always use the latest version.
 	IgnoreVersion bool `mapstructure:"ignore_version"`
 	// The Azure Vault KeyId to use for encryption and decryption
+	// KeyId is the full key string, example: https://secretkeyvault.vault.azure.net/keys/secrets-key/1111231232312111
 	KeyId string `mapstructure:"key_id"`
 
 	VaultName  string

--- a/secret/driver/base64.go
+++ b/secret/driver/base64.go
@@ -17,7 +17,9 @@ func NewBase64() (*Base64, error) {
 	return &driver, nil
 }
 
-func (p *Base64) Decrypt(encrypted string) (string, error) {
+func (p *Base64) Decrypt(encrypted string, key string) (string, error) {
+	// key is dismissed, as base64 isn't decrypting stuff
+
 	out, err := base64.StdEncoding.DecodeString(encrypted)
 	if err != nil {
 		return "", err
@@ -31,4 +33,8 @@ func (p *Base64) Encrypt(input string) (string, error) {
 
 func (p *Base64) Type() string {
 	return "base64"
+}
+
+func (p *Base64) GetPublicKey() string {
+	return "base64DoesNotHaveAPublicKey"
 }

--- a/secret/driver/base64.go
+++ b/secret/driver/base64.go
@@ -35,6 +35,6 @@ func (p *Base64) Type() string {
 	return "base64"
 }
 
-func (p *Base64) GetPublicKey() string {
-	return "base64DoesNotHaveAPublicKey"
+func (p *Base64) GetKey() string {
+	return "base64DoesNotHaveAKey"
 }

--- a/secret/driver/plain.go
+++ b/secret/driver/plain.go
@@ -14,7 +14,8 @@ func NewPlain() (*Plain, error) {
 }
 
 // the plain driver does not do anything
-func (p *Plain) Decrypt(encrypted string) (string, error) {
+func (p *Plain) Decrypt(encrypted string, key string) (string, error) {
+	// key is dismissed, as plain does not do anything
 	return encrypted, nil
 }
 
@@ -23,6 +24,10 @@ func (p *Plain) Encrypt(input string) (string, error) {
 	return input, nil
 }
 
-func (p *Plain) Type() string {
+func (p Plain) Type() string {
 	return "plain"
+}
+
+func (p Plain) GetPublicKey() string {
+	return "plainTextDoesntHaveAPublicKey"
 }

--- a/secret/driver/plain.go
+++ b/secret/driver/plain.go
@@ -29,5 +29,5 @@ func (p Plain) Type() string {
 }
 
 func (p Plain) GetKey() string {
-	return "plainTextDoesntHaveAKey"
+	return "plainDoesntHaveAKey"
 }

--- a/secret/driver/plain.go
+++ b/secret/driver/plain.go
@@ -28,6 +28,6 @@ func (p Plain) Type() string {
 	return "plain"
 }
 
-func (p Plain) GetPublicKey() string {
-	return "plainTextDoesntHaveAPublicKey"
+func (p Plain) GetKey() string {
+	return "plainTextDoesntHaveAKey"
 }


### PR DESCRIPTION
In our Project where we use skipper, we want to implement a feature where re-encryption of secrets is possible using a single command.

In our best-case scenario, we want to be able to replace the key in the inventory and let our project's CLI do the rest. But this means we have to know which was the OLD key and which is the NEW one, we want to re-encrypt our secrets with.

This change saves the "Public Key" (there's no such driver as of this PR, which uses a public key) or a Key Identifier (azurekv) to enable skipper to know which secret got encrypted with which key.
